### PR TITLE
use non-zero exit code when tests fail or error

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -42,5 +42,4 @@ if __name__ == '__main__':
     suites = load_suite_tests(only=only)
     suite = unittest.TestSuite(suites)
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    if result.failures:
-        sys.exit(bool(result.failures))
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Hi @Starou. I noticed Travis builds pass when tests raise an exception, e.g. https://travis-ci.org/Starou/django-thumborstorage/jobs/75400047. Here's the fix.
