### PR TITLE
Add Django 2.x to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
 
-python:
-  - 2.7
-  - 3.5
-  - 3.6
-
-env:
-  - DJANGO_VERSION=1.11.17
+matrix:
+  include:
+  - python: 2.7
+    env: DJANGO_VERSION=1.11.22
+  - python: 3.6
+    env: DJANGO_VERSION=1.11.22
+  - python: 3.6
+    env: DJANGO_VERSION=2.0.13
+  - python: 3.6
+    env: DJANGO_VERSION=2.1.10
+  - python: 3.6
+    env: DJANGO_VERSION=2.2.3
 
 install:
   - pip install -q Django==$DJANGO_VERSION


### PR DESCRIPTION
Use a Matrix to describe the couples Python/Django versions to test
since Django 2 is not compatible with Python2.

